### PR TITLE
bootstrap: skip gitconfig prompts in non-interactive shells

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -38,10 +38,26 @@ setup_gitconfig () {
       git_credential='osxkeychain'
     fi
 
-    user ' - What is your github author name?'
-    read -e git_authorname
-    user ' - What is your github author email?'
-    read -e git_authoremail
+    # Non-interactive sessions (CI, scripts) should not prompt.
+    # Provide values via env if desired:
+    #   DOTFILES_GIT_AUTHORNAME / DOTFILES_GIT_AUTHOREMAIL
+    # or standard git env:
+    #   GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+      git_authorname=${DOTFILES_GIT_AUTHORNAME:-${GIT_AUTHOR_NAME:-""}}
+      git_authoremail=${DOTFILES_GIT_AUTHOREMAIL:-${GIT_AUTHOR_EMAIL:-""}}
+
+      if [ -z "$git_authorname" ] || [ -z "$git_authoremail" ]; then
+        user " - Non-interactive shell detected; skipping gitconfig.local setup."
+        user "   Set DOTFILES_GIT_AUTHORNAME and DOTFILES_GIT_AUTHOREMAIL to enable." 
+        return 0
+      fi
+    else
+      user ' - What is your github author name?'
+      read -e git_authorname
+      user ' - What is your github author email?'
+      read -e git_authoremail
+    fi
 
     sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/gitconfig.local.symlink.example > git/gitconfig.local.symlink
 


### PR DESCRIPTION
In CI/non-interactive runs, 
  [ [00;34m..[0m ] setup gitconfig
  [ [0;33m??[0m ]  - Non-interactive shell detected; skipping gitconfig.local setup.
  [ [0;33m??[0m ]    Set DOTFILES_GIT_AUTHORNAME and DOTFILES_GIT_AUTHOREMAIL to enable.
  [ [00;34m..[0m ] installing dotfiles
[2K  [ [00;32mOK[0m ] linked /home/patrick/src/dotfiles/hammerspoon/hammerspoon.symlink to /home/patrick/.hammerspoon
[2K  [ [00;32mOK[0m ] linked /home/patrick/src/dotfiles/zsh/zshrc.symlink to /home/patrick/.zshrc
[2K  [ [00;32mOK[0m ] linked /home/patrick/src/dotfiles/git/gitignore.symlink to /home/patrick/.gitignore
  [ [0;33m??[0m ] File already exists: /home/patrick/.gitconfig (gitconfig.symlink), what do you want to do?
        [s]kip, [S]kip all, [o]verwrite, [O]verwrite all, [b]ackup, [B]ackup all? should not prompt for git author name/email. This change detects non-TTY sessions and skips setup unless DOTFILES_GIT_AUTHORNAME/DOTFILES_GIT_AUTHOREMAIL (or GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL) are provided.