### PR TITLE
git: move custom aliases into bin commands

### DIFF
--- a/bin/git-aliases
+++ b/bin/git-aliases
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git config -l | grep '^alias\.' | cut -c 7-

--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git branch --merged | egrep -v '(^\*|master|main)' | xargs git branch -d

--- a/bin/git-llgraph
+++ b/bin/git-llgraph
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git log --graph --oneline --decorate --branches --tags "$@"

--- a/bin/git-lllgraph
+++ b/bin/git-lllgraph
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git log --graph --oneline --decorate --all "$@"

--- a/bin/git-lsgraph
+++ b/bin/git-lsgraph
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git log --graph --pretty=format:"%C(yellow)%h%Cred%d\ %Creset%s%Cblue\[%cn]" --decorate "$@"

--- a/bin/git-pd
+++ b/bin/git-pd
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec git-pdiff "$@"

--- a/bin/git-pd
+++ b/bin/git-pd
@@ -1,3 +1,7 @@
 #!/usr/bin/env sh
 
-exec git-pdiff "$@"
+if [ "$#" -gt 0 ]; then
+  git diff --color -- "$@" | diff-so-fancy | less -R --tabs=3
+else
+  git diff --color | diff-so-fancy | less -R --tabs=3
+fi

--- a/bin/git-pdiff
+++ b/bin/git-pdiff
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-if [ "$#" -gt 0 ]; then
-  git diff --color -- "$@" | diff-so-fancy | less -R --tabs=3
-else
-  git diff --color | diff-so-fancy | less -R --tabs=3
-fi

--- a/bin/git-pdiff
+++ b/bin/git-pdiff
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git diff --color "$@" | diff-so-fancy | less -R --tabs=3

--- a/bin/git-pdiff
+++ b/bin/git-pdiff
@@ -1,3 +1,7 @@
 #!/usr/bin/env sh
 
-git diff --color "$@" | diff-so-fancy | less -R --tabs=3
+if [ "$#" -gt 0 ]; then
+  git diff --color -- "$@" | diff-so-fancy | less -R --tabs=3
+else
+  git diff --color | diff-so-fancy | less -R --tabs=3
+fi

--- a/bin/git-plog
+++ b/bin/git-plog
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git log --pretty=format:"%C(yellow)%h%Cred%d\ %Creset%s%Cblue\ [%an]" --decorate "$@"

--- a/bin/git-remove-whitespace-changes
+++ b/bin/git-remove-whitespace-changes
@@ -4,6 +4,6 @@
 # Does a checkout of all unstaged changes.
 # Unstages the changes from #1
 
-git addiws
+git-add-ignore-whitespace
 git checkout -- .
 git reset

--- a/bin/git-s
+++ b/bin/git-s
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+git status --short --branch "$@"

--- a/bin/git-spp
+++ b/bin/git-spp
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -e
+
+git stash save -u
+git pull "$@"
+git stash pop

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -3,45 +3,6 @@
   path = ~/.gitconfig.local
 
 
-[alias]
-  # Pretty prints the log with colors
-  plog = log --pretty=format:"%C(yellow)%h%Cred%d\\ %Creset%s%Cblue\\ [%an]" --decorate
-
-  # Pretty prints the graph with colors
-  lsgraph = log --graph --pretty=format:"%C(yellow)%h%Cred%d\\ %Creset%s%Cblue\\[%cn]" --decorate
-
-  # More verbose graph
-  llgraph = log --graph --oneline --decorate --branches --tags
-
-  # Very verbose graph
-  lllgraph = log --graph --oneline --decorate --all
-
-  # Pretty diff
-  pdiff = !git diff --color | diff-so-fancy | less -R --tabs=3
-
-  # Quick and pretty diff
-  pd = !git pdiff
-
-  # List aliases
-  la = !git config -l | grep alias | cut -c 7-
-
-  # Stage all changes that are more than just whitespace
-  addiws = !git add-ignore-whitespace
-
-  # Quick insight of Stash
-  s = !git status --short --branch
-
-  # Remove whitespace changes
-  rws = !git remove-whitespace-changes
-
-  # Deletes all branches that have been merged into `master` or `main`
-  delete-merged-branches = !git branch --merged | egrep -v '(^\\*|master|main)' | xargs git branch -d
-
-  # Pull latest using stash for local changes
-  spp = !git stash save -u && git pull && git stash pop
-
-  # Switch Default
-  sd = !git switch-default
 
 [color]
   diff = auto

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -53,3 +53,7 @@ unset config_files
 __log "Shell loaded."
 
 export PATH="$HOME/.local/bin:$PATH"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion


### PR DESCRIPTION
## Summary\n- move custom git aliases out of gitconfig and into  commands\n- remove the custom  block from \n- update dependent scripts to call the new bin commands directly\n\n## Added commands\n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n\n## Notes\nExisting commands that already lived in  remain there, including , , , and related helpers.